### PR TITLE
Fix for senec update

### DIFF
--- a/bundles/org.openhab.binding.senechome/README.md
+++ b/bundles/org.openhab.binding.senechome/README.md
@@ -25,7 +25,7 @@ Examples: Lights, pool filters, wash machines, ...
 demo.things
 
 ```java
-Thing senechome:senechome:pvbattery [ hostname="192.168.0.128", refreshInterval=60, limitationTresholdValue=70, limitationDuration=60, usePlain=false ]
+Thing senechome:senechome:pvbattery [ hostname="192.168.0.128", refreshInterval=60, limitationTresholdValue=70, limitationDuration=60, useHttp=false ]
 ```
 
 If the thing goes online then the connection to the web interface is successful.

--- a/bundles/org.openhab.binding.senechome/README.md
+++ b/bundles/org.openhab.binding.senechome/README.md
@@ -70,6 +70,13 @@ The property `limitationTresholdValue` is used as threshold for channel `powerLi
 | gridVoltagePhase2             | volt           | Grid voltage on Phase 2                                                  |
 | gridVoltagePhase3             | volt           | Grid voltage on Phase 3                                                  |
 | gridFrequency                 | hertz          | Grid frequency                                                           |
+| liveBatCharge                 | kilo watt hour | Live Total Bat Charge                                                    |
+| liveBatDischarge              | kilo watt hour | Live Total Bat Discharge                                                 |
+| liveGridImport                | kilo watt hour | Live Total Grid Import                                                   |
+| liveGridExport                | kilo watt hour | Live Total Grid Export                                                   |
+| liveHouseConsumption          | kilo watt hour | Live Total House Consumption (without WB)                                |
+| livePowerGenerator            | kilo watt hour | Live Total PV generator generated energy                                 |
+| liveEnergyWallbox1            | kilo watt hour | Live Total Wallbox 1 charged energy                                      |
 | chargedEnergyPack1            | kilo watt hour | total charged energy battery pack 1                                      |
 | chargedEnergyPack2            | kilo watt hour | total charged energy battery pack 2                                      |
 | chargedEnergyPack3            | kilo watt hour | total charged energy battery pack 3                                      |
@@ -135,6 +142,10 @@ Number SenecGridVoltagePh2       "Voltage Level on Phase 2 [%d V]"            <e
 Number SenecGridVoltagePh3       "Voltage Level on Phase 3 [%d V]"            <energy> { channel="senechome:senechome:pvbattery:gridVoltagePhase3" }
 Number SenecGridFrequency        "Grid Frequency [%.2f Hz]"                   <energy> { channel="senechome:senechome:pvbattery:gridFrequency" }
 Number SenecBatteryVoltage       "Battery Voltage [%.1f V]"                   <energy> { channel="senechome:senechome:pvbattery:batteryVoltage" }
+Number SenecLiveBatCharge        "Live Bat Charge [%d kWh]"                   <energy> { channel="senechome:senechome:pvbattery:liveBatCharge" }
+Number SenecLiveBatDischarge     "Live Bat Discharge [%d kWh]"                <energy> { channel="senechome:senechome:pvbattery:liveBatDischarge" }
+Number SenecLiveGridImport       "Live Grid Import [%d kWh]"                  <energy> { channel="senechome:senechome:pvbattery:liveGridImport" }
+Number SenecLiveGridExport       "Live Grid Export [%d kWh]"                  <energy> { channel="senechome:senechome:pvbattery:liveGridExport" }
 ```
 
 ## Sitemap
@@ -166,6 +177,10 @@ Text label="Power Grid"{
         Default item=SenecGridVoltagePh3
         Default item=SenecGridFrequency
         Default item=SenecBatteryVoltage
+        Default item=SenecLiveBatCharge
+        Default item=SenecLiveBatDischarge
+        Default item=SenecLiveGridImport
+        Default item=SenecLiveGridExport
     }
 }
 ```

--- a/bundles/org.openhab.binding.senechome/README.md
+++ b/bundles/org.openhab.binding.senechome/README.md
@@ -25,7 +25,19 @@ Examples: Lights, pool filters, wash machines, ...
 demo.things
 
 ```java
-Thing senechome:senechome:pvbattery [ hostname="192.168.0.128", refreshInterval=60, limitationTresholdValue=70, limitationDuration=60, useHttp=false ]
+Thing senechome:senechome:pvbattery [ 
+    hostname="192.168.0.128",
+    refreshInterval=60,
+    limitationTresholdValue=70,
+    limitationDuration=60,
+    useHttp=false,
+    // optional: mein-senec.de connection for statistic values
+    meinSenecRefreshInterval=300,
+    meinSenecUsername=address@mailprovider.com,
+    meinSenecPassword=SecretPassword,
+    // only required if you have more than one device registered in mein-senec.de
+    meinSenecDeviceId=1234
+]
 ```
 
 If the thing goes online then the connection to the web interface is successful.
@@ -70,13 +82,6 @@ The property `limitationTresholdValue` is used as threshold for channel `powerLi
 | gridVoltagePhase2             | volt           | Grid voltage on Phase 2                                                  |
 | gridVoltagePhase3             | volt           | Grid voltage on Phase 3                                                  |
 | gridFrequency                 | hertz          | Grid frequency                                                           |
-| liveBatCharge                 | kilo watt hour | Live Total Bat Charge                                                    |
-| liveBatDischarge              | kilo watt hour | Live Total Bat Discharge                                                 |
-| liveGridImport                | kilo watt hour | Live Total Grid Import                                                   |
-| liveGridExport                | kilo watt hour | Live Total Grid Export                                                   |
-| liveHouseConsumption          | kilo watt hour | Live Total House Consumption (without WB)                                |
-| livePowerGenerator            | kilo watt hour | Live Total PV generator generated energy                                 |
-| liveEnergyWallbox1            | kilo watt hour | Live Total Wallbox 1 charged energy                                      |
 | chargedEnergyPack1            | kilo watt hour | total charged energy battery pack 1                                      |
 | chargedEnergyPack2            | kilo watt hour | total charged energy battery pack 2                                      |
 | chargedEnergyPack3            | kilo watt hour | total charged energy battery pack 3                                      |
@@ -114,6 +119,18 @@ The property `limitationTresholdValue` is used as threshold for channel `powerLi
 | wallbox1ChargingCurrentPhase2 | ampere         | Wallbox 1 charging current Phase 2                                       |
 | wallbox1ChargingCurrentPhase3 | ampere         | Wallbox 1 charging current Phase 3                                       |
 | wallbox1ChargingPower         | watt           | Wallbox 1 charging power                                                 |
+
+If you configure the (Mein Senec)[https://mein-senec.de/] login username and password, you will also receive data in these channels:
+
+| Channel                       | Type           | Description                                                              |
+| ----------------------------- | -------------- | ------------------------------------------------------------------------ |
+| liveBatCharge                 | kilo watt hour | Live Total Bat Charge                                                    |
+| liveBatDischarge              | kilo watt hour | Live Total Bat Discharge                                                 |
+| liveGridImport                | kilo watt hour | Live Total Grid Import                                                   |
+| liveGridExport                | kilo watt hour | Live Total Grid Export                                                   |
+| liveHouseConsumption          | kilo watt hour | Live Total House Consumption (without WB)                                |
+| livePowerGenerator            | kilo watt hour | Live Total PV generator generated energy                                 |
+| liveEnergyWallbox1            | kilo watt hour | Live Total Wallbox 1 charged energy                                      |
 
 ## Items
 

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/MeinSenecApi.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/MeinSenecApi.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.senechome.internal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.openhab.binding.senechome.internal.json.MeinSenecResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+/**
+ * The {@link MeinSenecApi} class configures https client and performs status requests
+ *
+ * @author Korbinian Probst - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class MeinSenecApi {
+    private final Logger logger = LoggerFactory.getLogger(MeinSenecApi.class);
+    private static final String BASE_URL = "https://app-gateway-prod.senecops.com/v1/senec";
+    private final HttpClient httpClient;
+    private final Gson gson = new Gson();
+    private boolean isEnabled = false;
+    private String username = "";
+    private String password = "";
+    private String token = "";
+    private String deviceId = "";
+
+    public MeinSenecApi(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Return if the mein-senec.de api can be accessed
+     * 
+     * @return true = enabled, false = disabled
+     */
+    public boolean isEnabled() {
+        return this.isEnabled;
+    }
+
+    public void loginMeinSenec(String username, String password, String deviceId) {
+        // if username or password are empty, mein-senec.de stays disabled
+        if (username == null || username.isEmpty() || !username.contains("@")) {
+            logger.debug("No username given, mein-senec.de stays disabled");
+            return;
+        }
+        if (password == null || password.isEmpty()) {
+            logger.debug("No password given, mein-senec.de stays disabled");
+            return;
+        }
+
+        this.username = username;
+        this.password = password;
+
+        getLoginToken();
+        verifyDevice(deviceId);
+
+        // if the token could not be received or the device position not clarified, mein-senec.de stays disabled
+        if ((token.isEmpty()) || (this.deviceId.isEmpty())) {
+            logger.debug("Problems with token or deviceId, mein-senec.de stays disabled");
+        } else {
+            isEnabled = true;
+        }
+    }
+
+    /**
+     * If no login token is set, login to mein-senec.de to generate and store the token for future api calls
+     */
+    private void getLoginToken() {
+        try {
+            String loginUrl = BASE_URL + "/login";
+            Request request = httpClient.newRequest(loginUrl);
+
+            // Set the HTTP request method to POST
+            request.method(HttpMethod.POST);
+
+            // Create the payload data as a JSON string
+            Map<String, String> payloadData = new HashMap<>();
+            payloadData.put("username", username);
+            payloadData.put("password", password);
+            String payloadJson = gson.toJson(payloadData);
+
+            // Set the request content
+            request.content(new StringContentProvider(payloadJson), "application/json");
+
+            // Send the request
+            ContentResponse response = request.send();
+
+            if (response.getStatus() == 200) {
+                // Parse the JSON response to extract the access token
+                Map<String, Object> responseMap = gson.fromJson(response.getContentAsString(), Map.class);
+                // Code below looks strange because of the build error
+                // Null type mismatch: required 'java.lang.@NonNull String' but the provided value is inferred as
+                // @org.eclipse.jdt.annotation.Nullable
+                String local_token = (responseMap.get("token") instanceof String) ? (String) responseMap.get("token")
+                        : "";
+
+                if (local_token != null) {
+                    logger.debug("Login successful!");
+                    token = local_token;
+                } else {
+                    logger.error("Login failed. Token not found in response.");
+                    token = "";
+                }
+            } else {
+                logger.debug("Login failed with status code: {}", response.getStatus());
+            }
+        } catch (Exception e) {
+            logger.error("An error occurred during login: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Get all devices from mein-senec.de. Either only one device exists or the device with the given deviceId will be
+     * taken for fetching
+     * 
+     * @param deviceId optional
+     */
+    private void verifyDevice(String deviceId) {
+        List<Map<String, Object>> devicesData = null;
+
+        try {
+            String devicesUrl = BASE_URL + "/anlagen";
+            Request request = httpClient.newRequest(devicesUrl);
+
+            // Set the HTTP request method to GET
+            request.method(HttpMethod.GET);
+
+            // Set the authorization header
+            request.header("Authorization", token);
+
+            // Send the request
+            ContentResponse response = request.send();
+
+            if (response.getStatus() == 200) {
+                // Parse the JSON response to extract the list of devices
+                devicesData = gson.fromJson(response.getContentAsString(), List.class);
+
+                logger.debug("Devices Data:");
+                logger.debug("{}", gson.toJson(devicesData));
+
+                if (devicesData.size() == 0) {
+                    // No device, nothing to do
+                }
+                if (devicesData.size() == 1) {
+                    // With only one device just take it
+                    Map<String, Object> device = devicesData.get(0);
+                    String id = (String) device.get("id");
+                    if (id != null) {
+                        this.deviceId = id;
+                    }
+                } else if (deviceId.isEmpty()) {
+                    // if no device id is given but the size of the array is > 1, print all IDs
+                    logger.warn("There are {} devices configured in mein-senec.de, but no device id was configured.",
+                            devicesData.size());
+                    for (int i = 0; i < devicesData.size(); i++) {
+                        Map<String, Object> device = devicesData.get(i);
+                        String id = (String) device.get("id");
+                        String steuereinheitnummer = (String) device.get("steuereinheitnummer");
+                        String gehaeusenummer = (String) device.get("gehaeusenummer");
+                        String strasse = (String) device.get("strasse");
+                        String hausnummer = (String) device.get("hausnummer");
+                        String postleitzahl = (String) device.get("postleitzahl");
+                        String ort = (String) device.get("ort");
+                        String zeitzone = (String) device.get("zeitzone");
+                        String systemType = (String) device.get("systemType");
+                        logger.warn(
+                                "Id: {}, control device id: {}, housing id: {} address: {} {}, {} {}, timezone: {}, system type: {}",
+                                id, steuereinheitnummer, gehaeusenummer, strasse, hausnummer, postleitzahl, ort,
+                                zeitzone, systemType);
+                    }
+                } else {
+                    // If size > 1 and a device id was given, try to identify the position in the array
+                    for (int i = 0; i < devicesData.size(); i++) {
+                        Map<String, Object> device = devicesData.get(i);
+                        String id = (String) device.get("id");
+                        if (deviceId.equals(id)) {
+                            // Code below looks strange because of build error
+                            // Null type mismatch: required 'java.lang.@NonNull String' but the provided value is
+                            // inferred as @org.eclipse.jdt.annotation.Nullable
+                            String local_id = (id instanceof String) ? (String) id : "";
+                            this.deviceId = local_id;
+                            break; // Exit the loop once the device is found
+                        }
+                    }
+                }
+
+                // last verify that the device was found
+                if (this.deviceId.length() > 0) {
+                    logger.debug("Device ID {} found and verified", this.deviceId);
+                } else {
+                    logger.debug("Device ID not found in the devicesData array.");
+                }
+            } else {
+                logger.debug("Failed to retrieve devices with status code: {}", response.getStatus());
+                logger.debug("Request URL: {}", devicesUrl);
+
+                // Iterate over the headers
+                for (HttpField field : request.getHeaders()) {
+                    String headerName = field.getName();
+                    String headerValue = field.getValue();
+
+                    logger.debug("Header Name: {}", headerName);
+                    logger.debug("Header Value: {}", headerValue);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("An error occurred while retrieving devices: {}", e.getMessage());
+        }
+    }
+
+    public MeinSenecResponse getDashboard() {
+        try {
+            HttpClient httpClient = new HttpClient(new SslContextFactory.Client());
+            httpClient.start();
+
+            String dashboardUrl = BASE_URL + "/anlagen/" + deviceId + "/dashboard";
+            Request request = httpClient.newRequest(dashboardUrl);
+
+            // Set the HTTP request method to GET
+            request.method(HttpMethod.GET);
+
+            // Set the authorization header
+            request.header("Authorization", token);
+
+            // Send the request
+            ContentResponse response = request.send();
+
+            if (response.getStatus() == 200) {
+                // Parse the JSON response to extract dashboard data
+                // Map<String, Object> dashboardData = gson.fromJson(response.getContentAsString(), Map.class);
+
+                // logger.debug("Dashboard Data:");
+                // logger.debug("{}", gson.toJson(dashboardData, Map.class));
+
+                // // Convert the dashboardData map to a JSON string
+                // String dashboardJson = gson.toJson(dashboardData, Map.class);
+
+                // Deserialize the JSON string into a MeinSenecResponse object
+                // return Objects.requireNonNull(gson.fromJson(dashboardJson, MeinSenecResponse.class));
+                return Objects.requireNonNull(gson.fromJson(response.getContentAsString(), MeinSenecResponse.class));
+            } else {
+                logger.debug("Failed to retrieve dashboard data with status code: {}", response.getStatus());
+                logger.debug("Request URL: {}", dashboardUrl);
+
+                // Iterate over the headers
+                for (HttpField field : request.getHeaders()) {
+                    String headerName = field.getName();
+                    String headerValue = field.getValue();
+
+                    logger.debug("Header Name: {}", headerName);
+                    logger.debug("Header Value: {}", headerValue);
+                }
+            }
+
+        } catch (Exception e) {
+            logger.error("An error occurred while retrieving dashboard data: {}", e.getMessage());
+        }
+        // TODO what to return if everything breaks?
+        return new MeinSenecResponse();
+    }
+}

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeBindingConstants.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeBindingConstants.java
@@ -65,6 +65,15 @@ public class SenecHomeBindingConstants {
     public static final String CHANNEL_SENEC_GRID_VOLTAGE_PH3 = "gridVoltagePhase3";
     public static final String CHANNEL_SENEC_GRID_FREQUENCY = "gridFrequency";
 
+    // SenecHomeStatistics
+    public static final String CHANNEL_SENEC_LIVE_BAT_CHARGE = "liveBatCharge";
+    public static final String CHANNEL_SENEC_LIVE_BAT_DISCHARGE = "liveBatDischarge";
+    public static final String CHANNEL_SENEC_LIVE_GRID_IMPORT = "liveGridImport";
+    public static final String CHANNEL_SENEC_LIVE_GRID_EXPORT = "liveGridExport";
+    public static final String CHANNEL_SENEC_LIVE_HOUSE_CONSUMPTION = "liveHouseConsumption";
+    public static final String CHANNEL_SENEC_LIVE_POWER_GENERATOR = "livePowerGenerator";
+    public static final String CHANNEL_SENEC_LIVE_ENERGY_WALLBOX1 = "liveEnergyWallbox1";
+
     // SenecHomeBattery
     public static final String CHANNEL_SENEC_CHARGED_ENERGY_PACK1 = "chargedEnergyPack1";
     public static final String CHANNEL_SENEC_CHARGED_ENERGY_PACK2 = "chargedEnergyPack2";

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeConfigurationDTO.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeConfigurationDTO.java
@@ -23,4 +23,8 @@ public class SenecHomeConfigurationDTO {
     public int limitationTresholdValue = 95;
     public int limitationDuration = 120;
     public boolean useHttp = false;
+    public int meinSenecRefreshInterval = 300;
+    public String meinSenecUsername = "";
+    public String meinSenecPassword = "";
+    public String meinSenecDeviceId = "";
 }

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/SenecHomeHandler.java
@@ -197,21 +197,19 @@ public class SenecHomeHandler extends BaseThingHandler {
             updateQtyState(CHANNEL_SENEC_GRID_VOLTAGE_PH3, response.grid.currentGridVoltagePerPhase[2], 2, Units.VOLT);
             updateQtyState(CHANNEL_SENEC_GRID_FREQUENCY, response.grid.currentGridFrequency, 2, Units.HERTZ);
 
-            // updateQtyState(CHANNEL_SENEC_LIVE_BAT_CHARGE, response.statistics.liveBatCharge, 2, Units.KILOWATT_HOUR);
-            // updateQtyState(CHANNEL_SENEC_LIVE_BAT_DISCHARGE, response.statistics.liveBatDischarge, 2,
-            // Units.KILOWATT_HOUR);
-            // updateQtyState(CHANNEL_SENEC_LIVE_GRID_IMPORT, response.statistics.liveGridImport, 2,
-            // Units.KILOWATT_HOUR);
-            // updateQtyState(CHANNEL_SENEC_LIVE_GRID_EXPORT, response.statistics.liveGridExport, 2,
-            // Units.KILOWATT_HOUR);
-            // updateQtyState(CHANNEL_SENEC_LIVE_HOUSE_CONSUMPTION, response.statistics.liveHouseConsumption, 2,
-            // Units.KILOWATT_HOUR);
-            // updateQtyState(CHANNEL_SENEC_LIVE_POWER_GENERATOR, response.statistics.livePowerGenerator, 2,
-            // Units.KILOWATT_HOUR);
-            // if (response.statistics.liveWallboxEnergy != null) {
-            // updateQtyState(CHANNEL_SENEC_LIVE_ENERGY_WALLBOX1, response.statistics.liveWallboxEnergy[0], 2,
-            // Units.KILOWATT_HOUR, DIVISOR_ISO_TO_KILO);
-            // }
+            updateQtyState(CHANNEL_SENEC_LIVE_BAT_CHARGE, response.statistics.liveBatCharge, 2, Units.KILOWATT_HOUR);
+            updateQtyState(CHANNEL_SENEC_LIVE_BAT_DISCHARGE, response.statistics.liveBatDischarge, 2,
+                    Units.KILOWATT_HOUR);
+            updateQtyState(CHANNEL_SENEC_LIVE_GRID_IMPORT, response.statistics.liveGridImport, 2, Units.KILOWATT_HOUR);
+            updateQtyState(CHANNEL_SENEC_LIVE_GRID_EXPORT, response.statistics.liveGridExport, 2, Units.KILOWATT_HOUR);
+            updateQtyState(CHANNEL_SENEC_LIVE_HOUSE_CONSUMPTION, response.statistics.liveHouseConsumption, 2,
+                    Units.KILOWATT_HOUR);
+            updateQtyState(CHANNEL_SENEC_LIVE_POWER_GENERATOR, response.statistics.livePowerGenerator, 2,
+                    Units.KILOWATT_HOUR);
+            if (response.statistics.liveWallboxEnergy != null) {
+                updateQtyState(CHANNEL_SENEC_LIVE_ENERGY_WALLBOX1, response.statistics.liveWallboxEnergy[0], 2,
+                        Units.KILOWATT_HOUR, DIVISOR_ISO_TO_KILO);
+            }
 
             if (response.battery.chargedEnergy != null) {
                 updateQtyState(CHANNEL_SENEC_CHARGED_ENERGY_PACK1, response.battery.chargedEnergy[0], 2,

--- a/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/json/MeinSenecResponse.java
+++ b/bundles/org.openhab.binding.senechome/src/main/java/org/openhab/binding/senechome/internal/json/MeinSenecResponse.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.senechome.internal.json;
+
+import java.io.Serializable;
+
+/**
+ * Json model of mein-senec.de dashboard api, rebuilt by analyzing the api.
+ *
+ * @author Korbinian Probst - Initial Contribution
+ */
+public class MeinSenecResponse implements Serializable {
+    private Aktuell aktuell;
+    private Heute heute;
+    private String zeitstempel;
+    private boolean electricVehicleConnected;
+
+    public Aktuell getAktuell() {
+        return aktuell;
+    }
+
+    public Heute getHeute() {
+        return heute;
+    }
+
+    public String getZeitstempel() {
+        return zeitstempel;
+    }
+
+    public boolean isElectricVehicleConnected() {
+        return electricVehicleConnected;
+    }
+
+    public static class Aktuell implements Serializable {
+        private Wert stromerzeugung;
+        private Wert stromverbrauch;
+        private Wert netzeinspeisung;
+        private Wert netzbezug;
+        private Wert speicherbeladung;
+        private Wert speicherentnahme;
+        private Wert speicherfuellstand;
+        private Wert autarkie;
+        private Wert wallbox;
+
+        public Wert getStromerzeugung() {
+            return stromerzeugung;
+        }
+
+        public Wert getStromverbrauch() {
+            return stromverbrauch;
+        }
+
+        public Wert getNetzeinspeisung() {
+            return netzeinspeisung;
+        }
+
+        public Wert getNetzbezug() {
+            return netzbezug;
+        }
+
+        public Wert getSpeicherbeladung() {
+            return speicherbeladung;
+        }
+
+        public Wert getSpeicherentnahme() {
+            return speicherentnahme;
+        }
+
+        public Wert getSpeicherfuellstand() {
+            return speicherfuellstand;
+        }
+
+        public Wert getAutarkie() {
+            return autarkie;
+        }
+
+        public Wert getWallbox() {
+            return wallbox;
+        }
+    }
+
+    public static class Heute implements Serializable {
+        private Wert stromerzeugung;
+        private Wert stromverbrauch;
+        private Wert netzeinspeisung;
+        private Wert netzbezug;
+        private Wert speicherbeladung;
+        private Wert speicherentnahme;
+        private Wert speicherfuellstand;
+        private Wert autarkie;
+        private Wert wallbox;
+
+        public Wert getStromerzeugung() {
+            return stromerzeugung;
+        }
+
+        public Wert getStromverbrauch() {
+            return stromverbrauch;
+        }
+
+        public Wert getNetzeinspeisung() {
+            return netzeinspeisung;
+        }
+
+        public Wert getNetzbezug() {
+            return netzbezug;
+        }
+
+        public Wert getSpeicherbeladung() {
+            return speicherbeladung;
+        }
+
+        public Wert getSpeicherentnahme() {
+            return speicherentnahme;
+        }
+
+        public Wert getSpeicherfuellstand() {
+            return speicherfuellstand;
+        }
+
+        public Wert getAutarkie() {
+            return autarkie;
+        }
+
+        public Wert getWallbox() {
+            return wallbox;
+        }
+    }
+
+    public static class Wert implements Serializable {
+        private double wert;
+        private String einheit;
+
+        public double getWert() {
+            return wert;
+        }
+
+        public String getEinheit() {
+            return einheit;
+        }
+    }
+}

--- a/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
@@ -48,6 +48,15 @@
 			<channel id="gridVoltagePhase3" typeId="gridVoltagePhase3"/>
 			<channel id="gridFrequency" typeId="gridFrequency"/>
 
+			<!-- SenecHomeStatistics -->
+			<channel id="liveBatCharge" typeId="liveBatCharge"/>
+			<channel id="liveBatDischarge" typeId="liveBatDischarge"/>
+			<channel id="liveGridImport" typeId="liveGridImport"/>
+			<channel id="liveGridExport" typeId="liveGridExport"/>
+			<channel id="liveHouseConsumption" typeId="liveHouseConsumption"/>
+			<channel id="livePowerGenerator" typeId="livePowerGenerator"/>
+			<channel id="liveEnergyWallbox1" typeId="liveEnergyWallbox1"/>
+
 			<!-- SenecHomeBattery -->
 			<channel id="chargedEnergyPack1" typeId="chargedEnergyPack1"/>
 			<channel id="chargedEnergyPack2" typeId="chargedEnergyPack2"/>

--- a/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.senechome/src/main/resources/OH-INF/thing/thing-types.xml
@@ -123,10 +123,31 @@
 				<default>120</default>
 			</parameter>
 			<parameter name="useHttp" type="boolean" required="false">
-				<label>Http access</label>
+				<label>Http Access</label>
 				<description>Use legacy http access</description>
 				<default>false</default>
 			</parameter>
+			<parameter name="meinSenecRefreshInterval" type="integer" min="60" unit="s">
+				<label>Mein Senec Refresh Interval</label>
+				<description>Rate of refreshing details (in s)</description>
+				<default>300</default>
+			</parameter>
+			<parameter name="meinSenecUsername" type="text" required="false">
+				<label>Mein Senec Username</label>
+				<description>Enter the username that you use to login to mein-senec.de</description>
+				<context>email</context>
+			</parameter>
+			<parameter name="meinSenecPassword" type="text" required="false">
+				<label>Mein Senec Password</label>
+				<description>Enter the password that you use to login to mein-senec.de</description>
+				<context>password</context>
+			</parameter>
+			<parameter name="meinSenecDeviceId" type="text" required="false">
+				<label>Mein Senec Device ID</label>
+				<description>Enter the device id if you have more than one device connected at mein-senec.de. Leave it empty to take
+					the first and only device.</description>
+			</parameter>
+
 		</config-description>
 
 	</thing-type>


### PR DESCRIPTION
Implement connection to mein-senec.de to fetch the live* values (statistic).
The implementation ain't ready yet to merge, but is at least alive.

Known Problems:
- init doesn't work, I need to disable and enable the binding once
- too much logging, including sensitive data like the token
- no handling implemented if the token is outdated
- mostly untested
- instead of lifetime values I assign actual values
- for accessing mein-senec.de I would propose a slower refresh rate than for the local device. Config param is available but not implemented.